### PR TITLE
deviceStates: Add support for device states in ari-py

### DIFF
--- a/ari/client.py
+++ b/ari/client.py
@@ -237,6 +237,15 @@ class Client(object):
         """
         return self.on_object_event(event_type, fn, Endpoint, 'Endpoint')
 
+    def on_device_state_event(self, event_type, fn):
+        """Register callback for DeviceState related events
+
+        :param event_type: String name of the event to register for.
+        :param fn: Callback function
+        :type  fn: (DeviceState, dict) -> None or (list[DeviceState], dict) -> None
+        """
+        return self.on_object_event(event_type, fn, DeviceState, 'DeviceState')
+
     def on_sound_event(self, event_type, fn):
         """Register callback for Sound related events
 

--- a/ari/model.py
+++ b/ari/model.py
@@ -288,6 +288,21 @@ class Endpoint(BaseObject):
             client.on_endpoint_event)
 
 
+class DeviceState(BaseObject):
+    """First class object API.
+
+    :param client:  ARI client.
+    :type  client:  client.Client
+    :param endpoint_json: Instance data
+    """
+    id_generator = DefaultObjectIdGenerator('deviceName', id_field='name')
+
+    def __init__(self, client, device_state_json):
+        super(DeviceState, self).__init__(
+            client, client.swagger.devicestates, device_state_json,
+            client.on_device_state_event)
+
+
 class Sound(BaseObject):
     """First class object API.
 
@@ -341,5 +356,6 @@ CLASS_MAP = {
     'Endpoint': Endpoint,
     'Playback': Playback,
     'LiveRecording': LiveRecording,
-    'StoredRecording': StoredRecording
+    'StoredRecording': StoredRecording,
+    'DeviceState': DeviceState,
 }

--- a/ari_test/client_test.py
+++ b/ari_test/client_test.py
@@ -123,6 +123,15 @@ class ClientTest(AriTestCase):
             recordingName='test-recording')
         recording.deleteStored()
 
+    def test_device_state(self):
+        self.serve(PUT, 'deviceStates', 'foobar',
+                   body='{"name": "foobar", "state": "BUSY"}')
+        device_state = self.uut.deviceStates.update(
+            deviceName='foobar',
+            deviceState='BUSY')
+        self.assertEqual('foobar', device_state['name'])
+        self.assertEqual('BUSY', device_state['state'])
+
     def setUp(self):
         super(ClientTest, self).setUp()
         self.uut = ari.connect('http://ari.py/', 'test', 'test')

--- a/sample-api/deviceStates.json
+++ b/sample-api/deviceStates.json
@@ -1,0 +1,151 @@
+{
+	"_copyright": "Copyright (C) 2012 - 2013, Digium, Inc.",
+	"_author": "Kevin Harwell <kharwell@digium.com>",
+	"_svn_revision": "$Revision: 407402 $",
+	"apiVersion": "0.0.0-test",
+	"swaggerVersion": "1.1",
+	"basePath": "http://ari.py/ari",
+	"resourcePath": "/api-docs/deviceStates.{format}",
+	"apis": [
+		{
+			"path": "/deviceStates",
+			"description": "Device states",
+			"operations": [
+				{
+					"httpMethod": "GET",
+					"summary": "List all ARI controlled device states.",
+					"nickname": "list",
+					"responseClass": "List[DeviceState]"
+				}
+			]
+		},
+		{
+			"path": "/deviceStates/{deviceName}",
+			"description": "Device state",
+			"operations": [
+				{
+					"httpMethod": "GET",
+					"summary": "Retrieve the current state of a device.",
+					"nickname": "get",
+					"responseClass": "DeviceState",
+					"parameters": [
+						{
+							"name": "deviceName",
+							"description": "Name of the device",
+							"paramType": "path",
+							"required": true,
+							"allowMultiple": false,
+							"dataType": "string"
+						}
+					]
+				},
+				{
+					"httpMethod": "PUT",
+					"summary": "Change the state of a device controlled by ARI. (Note - implicitly creates the device state).",
+					"nickname": "update",
+					"responseClass": "void",
+					"parameters": [
+						{
+							"name": "deviceName",
+							"description": "Name of the device",
+							"paramType": "path",
+							"required": true,
+							"allowMultiple": false,
+							"dataType": "string"
+						},
+						{
+							"name": "deviceState",
+							"description": "Device state value",
+							"paramType": "query",
+							"required": true,
+							"allowMultiple": false,
+							"dataType": "string",
+						        "allowableValues": {
+							         "valueType": "LIST",
+							          "values": [
+								          "NOT_INUSE",
+								          "INUSE",
+								          "BUSY",
+								          "INVALID",
+								          "UNAVAILABLE",
+								          "RINGING",
+								          "RINGINUSE",
+								          "ONHOLD"
+								  ]
+						    }
+
+						}
+					],
+				        "errorResponses": [
+						{
+							"code": 404,
+							"reason": "Device name is missing"
+						},
+						{
+							"code": 409,
+							"reason": "Uncontrolled device specified"
+						}
+					]
+				},
+				{
+					"httpMethod": "DELETE",
+					"summary": "Destroy a device-state controlled by ARI.",
+					"nickname": "delete",
+					"responseClass": "void",
+					"parameters": [
+						{
+							"name": "deviceName",
+							"description": "Name of the device",
+							"paramType": "path",
+							"required": true,
+							"allowMultiple": false,
+							"dataType": "string"
+						}
+					],
+				        "errorResponses": [
+						{
+							"code": 404,
+							"reason": "Device name is missing"
+						},
+						{
+							"code": 409,
+							"reason": "Uncontrolled device specified"
+						}
+					]
+				}
+			]
+		}
+	],
+	"models": {
+		"DeviceState": {
+			"id": "DeviceState",
+			"description": "Represents the state of a device.",
+			"properties": {
+				"name": {
+					"type": "string",
+					"description": "Name of the device.",
+					"required": true
+				},
+				"state": {
+					"type": "string",
+					"description": "Device's state",
+					"required": true,
+					"allowableValues": {
+						"valueType": "LIST",
+						"values": [
+							"UNKNOWN",
+							"NOT_INUSE",
+							"INUSE",
+							"BUSY",
+							"INVALID",
+							"UNAVAILABLE",
+							"RINGING",
+							"RINGINUSE",
+							"ONHOLD"
+						]
+					}
+				}
+			}
+		}
+	}
+}

--- a/sample-api/resources.json
+++ b/sample-api/resources.json
@@ -34,6 +34,10 @@
 			"description": "Playback control resources"
 		},
 		{
+			"path": "/api-docs/deviceStates.{format}",
+			"description": "Device state resources"
+		},
+		{
 			"path": "/api-docs/events.{format}",
 			"description": "WebSocket resource"
 		},


### PR DESCRIPTION
This patch adds support for the ARI deviceStates resource. This includes
a sample-api resource as well as a very basic unit test for using PUT
to create/set the state of a device.
