### PR TITLE
ari/model: Fix DeviceState model resource path

### DIFF
--- a/ari/model.py
+++ b/ari/model.py
@@ -303,7 +303,7 @@ class DeviceState(BaseObject):
 
     def __init__(self, client, device_state_json):
         super(DeviceState, self).__init__(
-            client, client.swagger.devicestates, device_state_json,
+            client, client.swagger.deviceStates, device_state_json,
             client.on_device_state_event)
 
 


### PR DESCRIPTION
The correct path to the device state resource is 'deviceStates', not
'devicestate'. This patch corrects the misspelling so that swagger can find
the right resource.
