### PR TITLE
Application registered callback

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+0.2.0 (2016-04-20)
+------------------
+
+- Replace HTTPError with more specific exceptions (not retrocompatible)
+
 0.1.3 (2014-09-08)
 ------------------
 

--- a/ari/client.py
+++ b/ari/client.py
@@ -23,6 +23,7 @@ class Client(object):
     """
 
     def __init__(self, base_url, http_client):
+        self.base_url = base_url
         url = urlparse.urljoin(base_url, "ari/api-docs/resources.json")
 
         self.swagger = swaggerpy.client.SwaggerClient(

--- a/ari/exceptions.py
+++ b/ari/exceptions.py
@@ -1,0 +1,23 @@
+from requests import RequestException
+
+
+class ARIException(RequestException):
+    def __init__(self, ari_client, original_error):
+        self.client = ari_client
+        self.original_error = original_error
+
+
+class ARIHTTPError(ARIException):
+    pass
+
+
+class ARINotFound(ARIHTTPError):
+    pass
+
+
+class ARINotInStasis(ARIHTTPError):
+    pass
+
+
+class ARIServerError(ARIHTTPError):
+    pass

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup
 
 setup(
     name="ari",
-    version="0.1.3",
+    version="0.2.1",
     license="BSD 3-Clause License",
     description="Library for accessing the Asterisk REST Interface",
     long_description=open(os.path.join(os.path.dirname(__file__),


### PR DESCRIPTION
Make it possible to know that an application has been started as soon as possible to be able to subscribe to applications before they are used.

In my use case, I'm interested in ALL ChannelHold and ChannelUnhold events. Do receive those events, I have to call

```
client.applications.subscribe(applicationName='myapp', eventSource='channel:')
```

as soon as possible.

Usage:

```
client.on_application_registered('myapp', my_function)
```
