### PR TITLE
Avoid circular reference and prevent socket (connection) leak

### DIFF
--- a/ari/client.py
+++ b/ari/client.py
@@ -4,7 +4,7 @@
 
 """ARI client library.
 """
-
+import weakref
 import json
 import logging
 import urlparse
@@ -28,7 +28,7 @@ class Client(object):
         self.swagger = swaggerpy.client.SwaggerClient(
             url, http_client=http_client)
         self.repositories = {
-            name: Repository(self, name, api)
+            name: Repository(weakref.proxy(self), name, api)
             for (name, api) in self.swagger.resources.items()}
 
         # Extract models out of the events resource

--- a/ari/client.py
+++ b/ari/client.py
@@ -4,6 +4,7 @@
 
 """ARI client library.
 """
+
 import weakref
 import json
 import logging


### PR DESCRIPTION
While trying to identify a socket-leak I've realized that the ari.client  points to the repositories-object and which points back to the client . This causing a circular reference that prevents the execution of the destructor (\_\_del\_\_)  .
The net result is that if one creates a client object and delete it , the ARI socket to the asterisk is still open since no one calls the ".close()" method.  The user must then explicitly call the ".close" method (otherwise the HTTP socket  will stay in ESTABLISHED / FIN_WAIT for a while) .


In other words, the next code creates a leaked-socket (since the \_\_del\_\_ won't be called ):
```
client = ari.connect(...)
client = None
```

The solution that I found which seems to be working just fine is very simple - use the weakref.proxy() method when creating the repositories . This way there's no circular reference so the \_\_del\_\_ is being called right away and the socket is closed.