### PR TITLE
Return resp.content instead of json when response_class is binary

### DIFF
--- a/ari/model.py
+++ b/ari/model.py
@@ -367,6 +367,8 @@ def promote(client, resp, operation_json):
         return factory(client, resp_json)
     if resp.status_code == requests.codes.no_content:
         return None
+    if response_class == 'binary':
+        return resp.content
     log.info("No mapping for %s; returning JSON" % response_class)
     return resp.json()
 


### PR DESCRIPTION
When trying to get a stored recording with `client.recordings.getStoredFile` an exception is thrown, `ValueError: No JSON object could be decoded` as the content is not json. When the response_class is binary this returns the content directly without trying to parse it as json. 